### PR TITLE
Letting the user specify a timeframe for the report and log commands

### DIFF
--- a/chronolib/datetimes_test.go
+++ b/chronolib/datetimes_test.go
@@ -1,6 +1,7 @@
 package chronolib
 
 import (
+	"github.com/gofrs/uuid"
 	"github.com/jinzhu/now"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -14,4 +15,30 @@ func TestIsInsideTimeRange(t *testing.T) {
 
 	result := IsTimeInTimespan(point, start, end)
 	assert.Equal(t, result, true)
+}
+
+func TestSubFrameForTimespan(t *testing.T) {
+	start1, end1 := GetTimespanForDay("2019-12-20")
+	start2, end2 := GetTimespanForDay("2019-12-21")
+
+	frameStart, _ := now.Parse("2019-12-20 22:00")
+	frameEnd, _ := now.Parse("2019-12-21 1:00")
+
+	frame := Frame{
+		UUID: uuid.Must(uuid.NewV4()).String(),
+		Project: "test",
+		StartedAt: frameStart,
+		EndedAt: frameEnd,
+		UpdatedAt: frameEnd,
+		Tags: nil,
+		Notes: nil,
+	}
+
+	subFrame1 := SubFrameForTimespan(frame, start1, end1)
+	assert.Equal(t, subFrame1.StartedAt, frame.StartedAt)
+	assert.Equal(t, subFrame1.EndedAt, end1)
+
+	subFrame2 := SubFrameForTimespan(frame, start2, end2)
+	assert.Equal(t, subFrame2.StartedAt, start2)
+	assert.Equal(t, subFrame2.EndedAt, frame.EndedAt)
 }

--- a/chronolib/format.go
+++ b/chronolib/format.go
@@ -302,7 +302,9 @@ func FormatStartError(frame CurrentFrame) string {
 }
 
 // FormatReportDuration returns the duration currently being viewed in the report command
-func FormatReportDuration(timeStart time.Time) string {
-	today := time.Now()
-	return cyan(fmt.Sprintf("%s -> %s", FormatReportDurationDate(timeStart), FormatReportDurationDate(today)))
+func FormatReportDuration(timeStart time.Time, timeEnd time.Time) string {
+	if timeEnd.IsZero() {
+		timeEnd = time.Now()
+	}
+	return cyan(fmt.Sprintf("%s -> %s", FormatReportDurationDate(timeStart), FormatReportDurationDate(timeEnd)))
 }

--- a/commands/argparse.go
+++ b/commands/argparse.go
@@ -75,10 +75,10 @@ func ParseTime(t string) (time.Time, error) {
 // TimespanFlags is a struct containing the four different options for timespans
 type TimespanFlags struct {
 	AllTime      bool
-	CurrentWeek  bool
-	CurrentMonth bool
-	CurrentYear  bool
-	Yesterday    bool
+	Day          string
+	Week         string
+	Month        string
+	Year         string
 }
 
 // ParseTimespanFlags gets the correct start and end time for filtering frames based
@@ -87,14 +87,14 @@ func ParseTimespanFlags(timespanFlags TimespanFlags) chronolib.TimespanFilterOpt
 	var tsStart, tsEnd time.Time
 	if timespanFlags.AllTime {
 		return chronolib.TimespanFilterOptions{}
-	} else if timespanFlags.CurrentWeek {
-		tsStart, tsEnd = chronolib.GetTimespanForWeek()
-	} else if timespanFlags.CurrentMonth {
-		tsStart, tsEnd = chronolib.GetTimespanForMonth()
-	} else if timespanFlags.CurrentYear {
-		tsStart, tsEnd = chronolib.GetTimespanForYear()
-	} else if timespanFlags.Yesterday {
-		tsStart, tsEnd = chronolib.GetTimespanForYesterday()
+	} else if timespanFlags.Week != "" {
+		tsStart, tsEnd = chronolib.GetTimespanForWeek(timespanFlags.Week)
+	} else if timespanFlags.Month != "" {
+		tsStart, tsEnd = chronolib.GetTimespanForMonth(timespanFlags.Month)
+	} else if timespanFlags.Year != "" {
+		tsStart, tsEnd = chronolib.GetTimespanForYear(timespanFlags.Year)
+	} else if timespanFlags.Day != "" {
+		tsStart, tsEnd = chronolib.GetTimespanForDay(timespanFlags.Day)
 	} else {
 		tsStart, tsEnd = chronolib.GetTimespanForToday()
 	}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -16,7 +16,7 @@ const ChronoConfDirEnvName = "CHRONO_CONFIG_DIR"
 // ChronoAppConf is the name of the app's data directory
 const ChronoAppConf = "chrono"
 
-const mainDescription = `Chrono is a time to help track what you spend your time on.
+const mainDescription = `Chrono is a tool to help track what you spend your time on.
 
 You can start tracking your time with ` + "`start`" + ` and you can
 stop the timer with ` + "`stop`" + `.
@@ -107,6 +107,9 @@ var rootCmd = &cobra.Command{
 		if viper.GetBool("verbose") {
 			jww.SetLogThreshold(jww.LevelInfo)
 			jww.SetStdoutThreshold(jww.LevelInfo)
+		}
+		if os.Getenv("CHRONO_DEBUG") != "" {
+			jww.SetStdoutThreshold(jww.LevelDebug)
 		}
 		jww.INFO.Printf("using config dir: %s", configDir)
 		err := configdir.MakePath(configDir)

--- a/commands/log.go
+++ b/commands/log.go
@@ -11,11 +11,11 @@ import (
 )
 
 var interval int
-var logForCurrentWeek bool
-var logForCurrentMonth bool
-var logForCurrentYear bool
+var logForDay string
+var logForWeek string
+var logForMonth string
+var logForYear string
 var logForAllTime bool
-var logForYesterday bool
 var logFrom string
 var logTo string
 var round bool
@@ -53,8 +53,8 @@ func newLogCmd() *cobra.Command {
 			configDir := chronolib.GetCorrectConfigDirectory("")
 			config := chronolib.GetConfig(configDir)
 
-			if chronolib.ContainsMoreThanOneBooleanFlag(logForCurrentWeek, logForCurrentMonth, logForCurrentYear) {
-				fmt.Println("Error: the folllowing flags are mutually exclusive: ['--week', '--year', '--month']")
+			if chronolib.ContainsMoreThanOneBooleanFlag(logForDay != "", logForWeek != "", logForMonth != "", logForYear != "") {
+				fmt.Println("Error: the folllowing flags are mutually exclusive: ['--day', '--week', '--year', '--month']")
 				os.Exit(0)
 			}
 
@@ -69,10 +69,10 @@ func newLogCmd() *cobra.Command {
 			} else {
 				timespanFilterOptions = ParseTimespanFlags(TimespanFlags{
 					AllTime:      logForAllTime,
-					CurrentWeek:  logForCurrentWeek,
-					CurrentMonth: logForCurrentMonth,
-					CurrentYear:  logForCurrentYear,
-					Yesterday:    logForYesterday,
+					Day:          logForDay,
+					Week:         logForWeek,
+					Month:        logForMonth,
+					Year:         logForYear,
 				})
 			}
 
@@ -105,10 +105,14 @@ func newLogCmd() *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().BoolVarP(&logForCurrentWeek, "week", "w", false, "show frames for entire week")
-	cmd.Flags().BoolVarP(&logForCurrentMonth, "month", "m", false, "show frames for entire month")
-	cmd.Flags().BoolVarP(&logForCurrentYear, "year", "y", false, "show frames for entire year")
-	cmd.Flags().BoolVarP(&logForYesterday, "yesterday", "d", false, "show frames for yesterday")
+	cmd.Flags().StringVarP(&logForWeek, "week", "w", "", "show frames for entire week")
+	cmd.Flags().Lookup("week").NoOptDefVal = time.Now().Format("2006-01-02")
+	cmd.Flags().StringVarP(&logForMonth, "month", "m", "", "show frames for entire month")
+	cmd.Flags().Lookup("month").NoOptDefVal = time.Now().Format("2006-01")
+	cmd.Flags().StringVarP(&logForYear, "year", "y", "", "show frames for entire year")
+	cmd.Flags().Lookup("year").NoOptDefVal = time.Now().Format("2006")
+	cmd.Flags().StringVarP(&logForDay, "day", "d", "", "show frames for day")
+	cmd.Flags().Lookup("day").NoOptDefVal = time.Now().Format("2006-01-02")
 	cmd.Flags().BoolVarP(&logForAllTime, "all", "a", false, "show all frames")
 	cmd.Flags().BoolVarP(&round, "round", "r", false, "round frames start and end times to the nearest interval (default: 5 mins)")
 	cmd.Flags().StringVarP(&logFrom, "from", "f", "", "")

--- a/commands/report.go
+++ b/commands/report.go
@@ -9,9 +9,10 @@ import (
 	"time"
 )
 
-var reportForCurrentWeek bool
-var reportForCurrentMonth bool
-var reportForCurrentYear bool
+var reportForDay string
+var reportForWeek string
+var reportForMonth string
+var reportForYear string
 var reportForAllTime bool
 var reportTags []string
 var reportProjects []string
@@ -35,18 +36,20 @@ func newReportCmd() *cobra.Command {
 			config := chronolib.GetConfig(configDir)
 
 			if chronolib.ContainsMoreThanOneBooleanFlag(
-				reportForCurrentWeek, reportForCurrentMonth,
-				reportForCurrentYear, reportForAllTime,
+				reportForWeek != "", reportForMonth != "",
+				reportForYear != "", reportForDay != "",
+				reportForAllTime,
 			) {
-				fmt.Println("Error: the folllowing flags are mutually exclusive: ['--week', '--year', '--month', `--all`]")
+				fmt.Println("Error: the following flags are mutually exclusive: ['--day --week', '--year', '--month', `--all`]")
 				os.Exit(0)
 			}
 
 			timespanFilterOptions := ParseTimespanFlags(TimespanFlags{
 				AllTime:      reportForAllTime,
-				CurrentWeek:  reportForCurrentWeek,
-				CurrentMonth: reportForCurrentMonth,
-				CurrentYear:  reportForCurrentYear,
+				Day:          reportForDay,
+				Week:         reportForWeek,
+				Month:        reportForMonth,
+				Year:         reportForYear,
 			})
 
 			frames, _ := chronolib.GetFrames(config)
@@ -61,6 +64,7 @@ func newReportCmd() *cobra.Command {
 			totals := make(map[string]frameTotals)
 			fmt.Println(chronolib.FormatReportDuration(
 				timespanFilterOptions.Start,
+				timespanFilterOptions.End,
 			))
 			for _, date := range dates {
 				for _, frame := range timemap[date] {
@@ -96,9 +100,14 @@ func newReportCmd() *cobra.Command {
 		},
 	}
 
-	newReport.Flags().BoolVarP(&reportForCurrentWeek, "week", "w", false, "show frames for entire week")
-	newReport.Flags().BoolVarP(&reportForCurrentMonth, "month", "m", false, "show frames for entire month")
-	newReport.Flags().BoolVarP(&reportForCurrentYear, "year", "y", false, "show frames for entire year")
+	newReport.Flags().StringVarP(&reportForWeek, "week", "w", "", "show frames for entire week")
+	newReport.Flags().Lookup("week").NoOptDefVal = time.Now().Format("2006-01-02")
+	newReport.Flags().StringVarP(&reportForMonth, "month", "m", "", "show frames for entire month")
+	newReport.Flags().Lookup("month").NoOptDefVal = time.Now().Format("2006-01")
+	newReport.Flags().StringVarP(&reportForYear, "year", "y", "", "show frames for entire year")
+	newReport.Flags().Lookup("year").NoOptDefVal = time.Now().Format("2006")
+	newReport.Flags().StringVarP(&reportForDay, "day", "d", "", "show frames for day")
+	newReport.Flags().Lookup("day").NoOptDefVal = time.Now().Format("2006-01-02")
 	newReport.Flags().BoolVarP(&reportForAllTime, "all", "a", false, "show all frames")
 	newReport.Flags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
 	newReport.Flags().StringSliceVarP(&reportTags, "tag", "t", []string{}, "only show frames that contain the given tag - can be used multiple times")

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gookit/color v1.1.6
 	github.com/gookit/config v1.0.11
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/jinzhu/now v0.0.0-20180511015916-ed742868f2ae
+	github.com/jinzhu/now v1.1.1
 	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
 	github.com/magefile/mage v1.6.2
 	github.com/spf13/cobra v0.0.3
@@ -21,3 +21,5 @@ require (
 	google.golang.org/appengine v1.2.0 // indirect
 	gopkg.in/resty.v1 v1.9.1
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jinzhu/now v0.0.0-20180511015916-ed742868f2ae h1:8bBMcboXYVuo0WYH+rPe5mB8obO89a993hdTZ3phTjc=
 github.com/jinzhu/now v0.0.0-20180511015916-ed742868f2ae/go.mod h1:oHTiXerJ20+SfYcrdlBO7rzZRJWGwSTQ0iUY2jI6Gfc=
+github.com/jinzhu/now v1.1.1 h1:g39TucaRWyV3dwDO++eEc6qf8TVIQ/Da48WmqjZ3i7E=
+github.com/jinzhu/now v1.1.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f h1:dKccXx7xA56UNqOcFIbuqFjAWPVtP688j5QMgmo6OHU=
 github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f/go.mod h1:4rEELDSfUAlBSyUjPG0JnaNGjf13JySHFeRdD/3dLP0=
 github.com/magefile/mage v1.6.2 h1:33DJotH6JonQBppNt2GPIOWYBoPBrDGaXMe3dSrryxw=


### PR DESCRIPTION
As I work with Chrono, I find myself wanting to be able to get reports and, at times, logs for not just the current day, week, month, or year, but also previous ones.

**Example use case:** It is now 1st November, and I need to invoice my client for work done in October. I want to run:
```bash
$ chrono report --month="2019-10"
```
This pull request implements such functionality, for `--month`, --`week`, and `--year`.

:warning: This is my first time working with Go, so please don't hesitate to let me know if anything is missing or done the wrong way. This is why I'm sharing the PR here before it is complete.

### TODO before merging

- [X] Let user specify month for `month` flag
- [X] Let user specify week for `week` flag
- [X] Let user specify year for `year` flag
- [X] Let user specify day
- [x] Make sure tests are working
- [x] Update documentation